### PR TITLE
Use the consolidated PHP and JavaScript check workflows

### DIFF
--- a/.github/workflows/js-checks.yml
+++ b/.github/workflows/js-checks.yml
@@ -1,0 +1,23 @@
+# Run ESLint, Stylelint, package.json linting, and unit tests in a single job.
+#
+# Each check runs only when the project defines an npm script for it, so this
+# file is safe to sync to a repository that has only some of them. A check the
+# project is half set up for is reported on the pull request rather than failed.
+#
+# This file is managed in https://github.com/happyprime/projects
+name: JavaScript checks
+
+on: pull_request
+
+# The consolidated workflow comments on the pull request when a project is set
+# up for a check it cannot run. A workflow level permissions block caps what a
+# reusable workflow receives, so the write scope is granted here.
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  call-workflow:
+    uses: happyprime/workflows/.github/workflows/js-checks.yml@trunk
+    with:
+      node-version: 24

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
 				"@babel/preset-env": "^7.26.9",
 				"@happyprime/eslint-config": "^0.0.14",
 				"@rollup/plugin-node-resolve": "^16.0.1",
+				"@wordpress/npm-package-json-lint-config": "^5.10.0",
 				"archiver": "^7.0.1",
 				"babel-jest": "^29.7.0",
 				"jest": "^29.7.0",
@@ -3105,6 +3106,20 @@
 			"dev": true,
 			"license": "ISC",
 			"peer": true
+		},
+		"node_modules/@wordpress/npm-package-json-lint-config": {
+			"version": "5.52.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.52.0.tgz",
+			"integrity": "sha512-+3fv1jmdmsvSIhlZ2PpYKVQ6VQ1zKJFMTbHoJKSSiUA0Os5ASgAAH6S/+s4B0EGHZ94G3SV3k8oaiOnwOghE5Q==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"npm-package-json-lint": ">=6.0.0"
+			}
 		},
 		"node_modules/abab": {
 			"version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,17 @@
 	"description": "Intersection observer triggers based on class names.",
 	"author": "Happy Prime",
 	"license": "MIT",
+	"keywords": [
+		"happyprime",
+		"javascript"
+	],
+	"homepage": "https://github.com/happyprime/observe-triggers/",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/happyprime/observe-triggers.git"
+	},
+	"bugs": {
+		"url": "https://github.com/happyprime/observe-triggers/issues"
 	},
 	"files": [
 		"build"
@@ -18,6 +26,7 @@
 		"@babel/preset-env": "^7.26.9",
 		"@happyprime/eslint-config": "^0.0.14",
 		"@rollup/plugin-node-resolve": "^16.0.1",
+		"@wordpress/npm-package-json-lint-config": "^5.10.0",
 		"archiver": "^7.0.1",
 		"babel-jest": "^29.7.0",
 		"jest": "^29.7.0",
@@ -32,10 +41,14 @@
 		"build": "terser src/index.js -o build/index.js && npm run build:wordpress",
 		"build:wordpress": "npm run build:wordpress:script && node tools/build-wordpress-integration.js",
 		"build:wordpress:script": "rollup -c",
-		"lint": "eslint .",
+		"lint": "npm run lint:js",
 		"fix": "eslint . --fix",
 		"test": "jest",
-		"lint:package": "node ./node_modules/npm-package-json-lint/dist/cli.js ./",
-		"watch": "nodemon --watch src --ext js --exec 'npm run build'"
+		"lint:package": "node ./node_modules/npm-package-json-lint/dist/cli.js ./package.json",
+		"watch": "nodemon --watch src --ext js --exec 'npm run build'",
+		"lint:js": "eslint ."
+	},
+	"npmpackagejsonlint": {
+		"extends": "@wordpress/npm-package-json-lint-config"
 	}
 }


### PR DESCRIPTION
Replaces the single-purpose check workflows with the consolidated `php-checks` and `js-checks` workflows from [happyprime/workflows](https://github.com/happyprime/workflows).

Each consolidated workflow pays for checkout, language setup, and dependency install once instead of once per check, and runs every check it finds configured so a single push reports every problem at once.

### What this changes here

- Adds `.github/workflows/js-checks.yml`.
- No existing check workflows to remove.
- npm scripts detected: ESLint (`npm run lint`), package.json lint (`npm run lint:package`), Unit tests (`npm run test`).

### Checks running in CI here for the first time

These are configured in the repository but had no workflow, so this pull request is the first time they run. A failure below is a pre-existing issue this surfaces, not something this pull request introduces:

- ESLint
- package.json lint
- Unit tests

A check that is configured but cannot run (missing binary, missing `bin/install-wp-tests.sh`, a config with no npm script) is skipped and reported in a pull request comment rather than failed.

Once this is merged the two files move under sync management in `happyprime/projects`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)